### PR TITLE
AC presets and passive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ It is designed for users who want a cleaner, more modern SmartIR experience with
 - 📚 Includes a **Broadlink learn service** for saving replacement commands
 - 🔄 Includes command conversion support between **Base64**, **HEX**, **Pronto**, and **Raw** where applicable
 - 🧩 Supports Home Assistant's native **Infrared** emitter entities on HA 2026.4+
+- 🎛️ Optional **AC presets** (Eco, Quiet, Comfort, …) via an optional `presetModes` key in climate codesets
+- 🛑 Optional **Passive mode** for climate — never re-sends unchanged state, letting the AC unit's own thermostat manage temperature
 - ⚡ Updated for newer Home Assistant patterns and compatibility
 
 ---
@@ -232,7 +234,26 @@ HEX
 Pronto
 Raw
 
+🎛️ Climate Presets (optional)
+Climate codesets can optionally declare AC presets (e.g. Eco, Quiet, Comfort on Samsung units) by adding a `presetModes` key. When present, an extra preset level sits between the fan/swing level and the temperatures:
 
+{
+  "presetModes": ["eco", "quiet"],
+  "commands": {
+    "off": "JgBQAAAB...",
+    "cool": {
+      "auto": {
+        "none": { "18": "JgBQ...", "19": "JgBQ..." },
+        "eco":  { "18": "JgBQ...", "19": "JgBQ..." }
+      }
+    }
+  }
+}
+
+The "none" preset holds the standard commands. If a preset is missing at any point in the tree, the integration falls back to "none" (or the flat temperature layout). Existing codesets without `presetModes` are completely unaffected and keep the original format.
+
+🛑 Passive Mode (optional)
+Climate entities have an optional Passive mode toggle in the setup and options flow. When enabled, AR Smart IR never re-sends a command unless something actually changed (mode, fan, swing, preset, or target temperature), and only sends the discrete "on" command when the unit is genuinely being switched on. This lets the AC unit's own built-in thermostat and hysteresis manage the temperature — AR Smart IR only transmits when you make a control change. It is off by default, so existing setups behave exactly as before.
 
 📌 Notes
 This project was originally based on and tested around Broadlink, but support has expanded significantly beyond that

--- a/custom_components/ar_smart_ir/climate.py
+++ b/custom_components/ar_smart_ir/climate.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_COMMAND_OVERRIDES,
     CONF_CONTROLLER,
     CONF_HUMIDITY_SENSOR,
+    CONF_PASSIVE_MODE,
     CONF_POWER_SENSOR,
     CONF_POWER_SENSOR_RESTORE_STATE,
     CONF_TEMPERATURE_SENSOR,
@@ -40,6 +41,7 @@ CONF_CONTROLLER_DATA = "controller_data"
 CONF_DELAY = "delay"
 
 DEFAULT_DELAY = 0.5
+PRESET_NONE = "none"
 SENSOR_STATES_INVALID = {STATE_UNKNOWN, STATE_UNAVAILABLE, None, ""}
 
 SUPPORT_FLAGS = (
@@ -103,6 +105,14 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         self._fan_modes = device_data["fanModes"]
         self._swing_modes = device_data.get("swingModes")
 
+        # Optional AC presets (issue #28). Older codesets without a
+        # "presetModes" key are completely unaffected.
+        raw_presets = device_data.get("presetModes") or []
+        self._preset_modes = None
+        if raw_presets:
+            presets = [p for p in raw_presets if p != PRESET_NONE]
+            self._preset_modes = [PRESET_NONE] + presets
+
         self._commands = device_data["commands"]
 
         self._target_temperature = self._min_temperature
@@ -110,7 +120,13 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
 
         self._current_fan_mode = self._fan_modes[0]
         self._current_swing_mode = None
+        self._current_preset_mode = PRESET_NONE if self._preset_modes else None
         self._last_on_operation = None
+
+        # Passive mode (issue #31): when enabled, identical state commands are
+        # never re-sent, so the AC unit's own thermostat manages temperature.
+        self._passive_mode = bool(config.get(CONF_PASSIVE_MODE, False))
+        self._last_sent_state = None
 
         self._current_temperature = None
         self._current_humidity = None
@@ -122,6 +138,9 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             self._support_flags |= ClimateEntityFeature.SWING_MODE
             self._current_swing_mode = self._swing_modes[0]
             self._support_swing = True
+
+        if self._preset_modes:
+            self._support_flags |= ClimateEntityFeature.PRESET_MODE
 
         self._temp_lock = asyncio.Lock()
         self._on_by_remote = False
@@ -153,6 +172,10 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
                 "swing_mode",
                 self._current_swing_mode,
             )
+            if self._preset_modes:
+                restored_preset = last_state.attributes.get("preset_mode")
+                if restored_preset in self._preset_modes:
+                    self._current_preset_mode = restored_preset
             self._last_on_operation = last_state.attributes.get("last_on_operation")
 
         self._update_current_temperature()
@@ -250,6 +273,14 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         return self._current_swing_mode
 
     @property
+    def preset_modes(self):
+        return self._preset_modes
+
+    @property
+    def preset_mode(self):
+        return self._current_preset_mode
+
+    @property
     def supported_features(self):
         return self._support_flags
 
@@ -262,6 +293,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             "supported_models": self._supported_models,
             "supported_controller": self._supported_controller,
             "commands_encoding": self._commands_encoding,
+            "passive_mode": self._passive_mode,
         }
 
     @callback
@@ -372,6 +404,17 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
 
         self.async_write_ha_state()
 
+    async def async_set_preset_mode(self, preset_mode):
+        if not self._preset_modes or preset_mode not in self._preset_modes:
+            return
+
+        self._current_preset_mode = preset_mode
+
+        if self._hvac_mode != HVACMode.OFF:
+            await self.send_command()
+
+        self.async_write_ha_state()
+
     async def async_turn_on(self):
         target_mode = self._last_on_operation
         if target_mode is None:
@@ -380,6 +423,30 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
 
     async def async_turn_off(self):
         await self.async_set_hvac_mode(HVACMode.OFF)
+
+    def _resolve_state_command(self, operation_mode, fan_mode, temp):
+        """Resolve the command for the current state.
+
+        Standard layout (unchanged): commands[mode][fan][(swing)][temp]
+        With presets (optional):     commands[mode][fan][(swing)][preset][temp]
+
+        Codesets without a preset layer keep working exactly as before.
+        """
+        node = self._commands[operation_mode][fan_mode]
+
+        if self._support_swing:
+            node = node[self._current_swing_mode]
+
+        if self._preset_modes:
+            preset = self._current_preset_mode or PRESET_NONE
+            if isinstance(node, dict):
+                if preset in node and isinstance(node[preset], dict):
+                    node = node[preset]
+                elif PRESET_NONE in node and isinstance(node[PRESET_NONE], dict):
+                    node = node[PRESET_NONE]
+                # else: codeset has no preset layer here — fall through to temps
+
+        return node[temp]
 
     async def send_command(self):
         async with self._temp_lock:
@@ -390,20 +457,34 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
 
                 if operation_mode == HVACMode.OFF:
                     await self._controller.send(self._commands["off"])
+                    self._last_sent_state = None
+                    return
+
+                state_key = (
+                    operation_mode,
+                    fan_mode,
+                    self._current_swing_mode,
+                    self._current_preset_mode,
+                    temp,
+                )
+
+                if self._passive_mode and state_key == self._last_sent_state:
+                    # Passive mode: nothing changed, let the AC unit's own
+                    # thermostat do its job — don't re-send.
                     return
 
                 if "on" in self._commands:
-                    await self._controller.send(self._commands["on"])
-                    await asyncio.sleep(self._delay)
+                    # In passive mode only send the discrete "on" when we are
+                    # actually turning the unit on, not on every adjustment.
+                    if not self._passive_mode or self._last_sent_state is None:
+                        await self._controller.send(self._commands["on"])
+                        await asyncio.sleep(self._delay)
 
-                if self._support_swing:
-                    await self._controller.send(
-                        self._commands[operation_mode][fan_mode][self._current_swing_mode][temp]
-                    )
-                else:
-                    await self._controller.send(
-                        self._commands[operation_mode][fan_mode][temp]
-                    )
+                await self._controller.send(
+                    self._resolve_state_command(operation_mode, fan_mode, temp)
+                )
+
+                self._last_sent_state = state_key
 
             except Exception as err:
                 _LOGGER.exception("SmartIR send command failed: %s", err)

--- a/custom_components/ar_smart_ir/config_flow.py
+++ b/custom_components/ar_smart_ir/config_flow.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_OVERRIDE_REPEAT_COUNT,
     CONF_OVERRIDE_REPEAT_DELAY,
     CONF_PLATFORM,
+    CONF_PASSIVE_MODE,
     CONF_POWER_SENSOR,
     CONF_POWER_SENSOR_RESTORE_STATE,
     CONF_SOURCE_NAMES,
@@ -431,6 +432,12 @@ class ARSmartIRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_POWER_SENSOR_RESTORE_STATE,
                     default=current_values.get(CONF_POWER_SENSOR_RESTORE_STATE, False),
+                )
+            ] = bool
+            data_schema[
+                vol.Optional(
+                    CONF_PASSIVE_MODE,
+                    default=current_values.get(CONF_PASSIVE_MODE, False),
                 )
             ] = bool
 
@@ -986,6 +993,12 @@ class ARSmartIROptionsFlow(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_POWER_SENSOR_RESTORE_STATE,
                     default=data.get(CONF_POWER_SENSOR_RESTORE_STATE, False),
+                )
+            ] = bool
+            schema[
+                vol.Optional(
+                    CONF_PASSIVE_MODE,
+                    default=data.get(CONF_PASSIVE_MODE, False),
                 )
             ] = bool
 

--- a/custom_components/ar_smart_ir/const.py
+++ b/custom_components/ar_smart_ir/const.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 DOMAIN = "ar_smart_ir"
-VERSION = "1.6.0"
+VERSION = "1.7.0"
 
 CONF_PLATFORM = "platform"
 CONF_UNIQUE_ID = "unique_id"
@@ -15,6 +15,7 @@ CONF_TEMPERATURE_SENSOR = "temperature_sensor"
 CONF_HUMIDITY_SENSOR = "humidity_sensor"
 CONF_POWER_SENSOR = "power_sensor"
 CONF_POWER_SENSOR_RESTORE_STATE = "power_sensor_restore_state"
+CONF_PASSIVE_MODE = "passive_mode"
 CONF_SOURCE_NAMES = "source_names"
 CONF_DEVICE_CLASS = "device_class"
 CONF_COMMAND_OVERRIDES = "command_overrides"

--- a/custom_components/ar_smart_ir/manifest.json
+++ b/custom_components/ar_smart_ir/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "aiofiles>=23.1.0"
   ],
-  "version": "1.6.0"
+  "version": "1.7.0"
 }

--- a/custom_components/ar_smart_ir/strings.json
+++ b/custom_components/ar_smart_ir/strings.json
@@ -50,8 +50,13 @@
           "temperature_sensor": "Temperature sensor",
           "humidity_sensor": "Humidity sensor",
           "power_sensor_restore_state": "Restore HVAC state from power sensor",
+          "passive_mode": "Passive mode",
           "device_class": "Media player class",
           "source_names": "Optional source remap JSON / text"
+        },
+        "data_description": {
+          "passive_mode": "Only transmit IR when you change a setting. Unchanged states are never re-sent, so the AC unit's own thermostat manages the temperature.",
+          "power_sensor_restore_state": "When the power sensor turns on, restore the last HVAC mode instead of defaulting to cool."
         }
       },
       "name": {

--- a/custom_components/ar_smart_ir/translations/en.json
+++ b/custom_components/ar_smart_ir/translations/en.json
@@ -44,7 +44,11 @@
           "humidity_sensor": "Humidity sensor",
           "go_back": "Go back to controller selection",
           "test_command": "Test command",
-          "test_device": "Send test command instead of saving"
+          "test_device": "Send test command instead of saving",
+          "passive_mode": "Passive mode"
+        },
+        "data_description": {
+          "passive_mode": "Only transmit IR when you change a setting. Unchanged states are never re-sent, so the AC unit's own thermostat manages the temperature."
         }
       }
     },
@@ -78,7 +82,11 @@
           "override_sequence_step_4": "Sequence step 4",
           "override_sequence_step_5": "Sequence step 5",
           "override_remove": "Remove selected override",
-          "learn_command": "Open IR learn wizard (Broadlink / LinkNLink)"
+          "learn_command": "Open IR learn wizard (Broadlink / LinkNLink)",
+          "passive_mode": "Passive mode"
+        },
+        "data_description": {
+          "passive_mode": "Only transmit IR when you change a setting. Unchanged states are never re-sent, so the AC unit's own thermostat manages the temperature."
         }
       },
       "learn": {


### PR DESCRIPTION
Adds two optional climate features. No breaking changes — existing codesets, configs, and automations are unaffected.
AC Presets — climate codesets can declare a presetModes key (Eco, Quiet, Comfort, …) with an optional preset level in the commands tree. Presets show up as native HA presets on the thermostat. Missing presets fall back to "none"; codesets without the key keep the exact same format and behaviour. CI validation updated to understand the preset layer.
Closes #28
Passive Mode — new per-entity toggle (default off). When enabled, IR is only transmitted when a setting actually changes: identical states are never re-sent and the discrete "on" command is only sent on a real off → on transition, so the AC unit's own thermostat manages temperature undisturbed.
Closes #31
Also: setup/options dialog now uses short labels with helper text, and the repo guard size cap is raised to 3 MB for large swing-mode codesets.