### PR TITLE
Convert restored target temperature from display unit before clamping

### DIFF
--- a/custom_components/ar_smart_ir/climate.py
+++ b/custom_components/ar_smart_ir/climate.py
@@ -307,11 +307,18 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             )
 
     def _restore_target_temperature(self, value):
-        """Bring a restored target temperature back into range.
+        """Bring a restored target temperature back into the codeset's unit and range.
+
+        Home Assistant serialises a climate entity's "temperature" attribute
+        in the *display* unit (hass.config.units.temperature_unit), not the
+        entity's native unit, so on an imperial system a 22 °C target is
+        stored as 72. Convert it back into the codeset's unit before doing
+        anything else; without that, 72 reads as 72 °C and clamps to the
+        codeset maximum.
 
         A state saved by an older version - or before the unit override was
-        changed - can be in a different unit entirely (issue #33: a 65 °C
-        target was written out as 149 °F). Sending that would look up a
+        changed - can still be in a different unit entirely (issue #33: a
+        65 °C target was written out as 149 °F). Sending that would look up a
         command key that doesn't exist, so clamp it into the codeset's own
         range instead of failing on the next command.
         """
@@ -328,6 +335,14 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
                 self._min_temperature,
             )
             return self._min_temperature
+
+        display_unit = self.hass.config.units.temperature_unit
+        if display_unit != self._temperature_unit:
+            value = TemperatureConverter.convert(
+                value,
+                display_unit,
+                self._temperature_unit,
+            )
 
         if self._precision == PRECISION_WHOLE:
             value = round(value)


### PR DESCRIPTION
## The bug

On every Home Assistant restart, a climate entity's restored target temperature is clamped to the codeset maximum whenever HA's display unit differs from the codeset's unit. On an imperial (°F) system with a Celsius codeset (e.g. device `1410.json`, Samsung, 16–30 °C), a 22 °C target comes back after every restart as 30 °C (86 °F).

## Cause

Home Assistant serialises a climate entity's `temperature` state attribute in the **display** unit: `ClimateEntity.state_attributes` passes `target_temperature` through the `show_temp` helper, which converts into `hass.config.units.temperature_unit`. So on an imperial system the stored attribute for a 22 °C target is `72`.

`_restore_target_temperature` compared that raw stored value directly against `self._min_temperature` / `self._max_temperature`, which are in the codeset's own unit (`self._temperature_unit`). `72` is judged out of the 16–30 range and clamped, producing this log line on every boot:

```
smartir_climate: restored target temperature 72 is outside the codeset range 16.0-30.0 °C, clamping to 30.0
```

This is a different concern from #33 (related context, not a duplicate): #33 and the `temperature_unit` config option are about what unit the **codeset** is written in. This bug is about the unit HA stores the **restored state** in, which is the display unit regardless of the codeset's unit.

## Fix

Convert the restored value from `hass.config.units.temperature_unit` into `self._temperature_unit` before rounding and clamping, following the existing `TemperatureConverter` pattern already used for the external temperature sensor path.

Notes:

- `hass.config.units.temperature_unit` is the correct and only source for the stored unit: climate entities have no per-entity unit override in the entity registry (those exist only for `sensor`/`number`), so `show_temp` only ever converts into the system unit.
- When the display unit and codeset unit already match, the conversion is skipped and behaviour is byte-for-byte unchanged.
- Genuinely out-of-range values (e.g. a state saved under a different unit configuration, as in #33) still clamp into the codeset range afterwards.

## Testing

The repo has no test infrastructure, so verification was done two ways:

1. A standalone harness driving the real `_restore_target_temperature` with stubbed HA modules, run against both the old and patched file:
   - old: `72` (°F display, °C codeset) → clamped to `30.0` — reproduces the bug; patched: → `22`
   - `61` °F → `16` °C (range minimum survives the round trip)
   - `100` °F → 37.8 °C → still clamps to `30.0`; `32` °F → 0 °C → clamps to `16.0`
   - matching units: `22` → `22`, `65` → `30.0` — unchanged behaviour
   - `None` / unparsable input paths unchanged
   - 0.5-precision round trip: `72.5` °F → `22.5` °C
2. Live: deployed on HA 2026.7 (imperial system, codeset `1410.json`) — before the patch the target reset to 86 °F on every restart; after the patch a restart preserves the set target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

