### PR TITLE
fix(climate): sync HVAC state with power sensor on startup

### DIFF
--- a/custom_components/ar_smart_ir/climate.py
+++ b/custom_components/ar_smart_ir/climate.py
@@ -305,6 +305,27 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
                     self._async_power_sensor_changed,
                 )
             )
+            # Initial sync: reconcile restored state with the actual power
+            # sensor so the entity is correct after a restart even if the
+            # sensor never changes.
+            power_state = self.hass.states.get(self._power_sensor)
+            if power_state is not None:
+                if power_state.state == "off" and self._hvac_mode != HVACMode.OFF:
+                    self._on_by_remote = False
+                    self._hvac_mode = HVACMode.OFF
+                elif power_state.state == "on" and self._hvac_mode == HVACMode.OFF:
+                    self._on_by_remote = True
+                    if (
+                        self._power_sensor_restore_state
+                        and self._last_on_operation is not None
+                    ):
+                        self._hvac_mode = self._last_on_operation
+                    else:
+                        self._hvac_mode = (
+                            self._operation_modes[1]
+                            if len(self._operation_modes) > 1
+                            else HVACMode.COOL
+                        )
 
     def _restore_target_temperature(self, value):
         """Bring a restored target temperature back into the codeset's unit and range.


### PR DESCRIPTION
## Summary

The climate entity only reacted to *changes* on the configured power sensor.
After a Home Assistant restart the entity restored its last known HVAC mode
without checking the sensor's current state, so an AC that was off could come
back as COOL (or vice versa) and stay wrong until the sensor next flipped.

## Changes

- `climate.py`: added an initial reconciliation step in `async_added_to_hass()`
  that reads the power sensor's current state immediately after registering the
  state-change listener, and corrects `_hvac_mode` / `_on_by_remote` if the
  restored state disagrees.
- Mirrors the existing `_async_power_sensor_changed()` logic, including
  `power_sensor_restore_state` and `last_on_operation` handling, so behaviour
  is consistent between startup and runtime.

