### PR TITLE
fix(fan,light): correct turn_on/turn_off signatures + climate power sensor startup sync

### DIFF
--- a/custom_components/ar_smart_ir/fan.py
+++ b/custom_components/ar_smart_ir/fan.py
@@ -256,7 +256,10 @@ class SmartIRFan(FanEntity, RestoreEntity):
 
         self.async_write_ha_state()
 
-    async def async_turn_on(self, percentage=None, **kwargs):
+    async def async_turn_on(self, percentage=None, preset_mode=None, **kwargs):
+        # Home Assistant calls async_turn_on(percentage, preset_mode, **kwargs)
+        # positionally, so preset_mode must be accepted even though this
+        # platform does not expose preset modes.
 
         if percentage is None:
             percentage = ordered_list_item_to_percentage(
@@ -266,7 +269,7 @@ class SmartIRFan(FanEntity, RestoreEntity):
 
         await self.async_set_percentage(percentage)
 
-    async def async_turn_off(self):
+    async def async_turn_off(self, **kwargs):
 
         await self.async_set_percentage(0)
 

--- a/custom_components/ar_smart_ir/light.py
+++ b/custom_components/ar_smart_ir/light.py
@@ -287,7 +287,7 @@ class SmartIRLight(LightEntity, RestoreEntity):
 
         self.async_write_ha_state()
 
-    async def async_turn_off(self):
+    async def async_turn_off(self, **kwargs):
         await self.send_command(CMD_POWER_OFF)
 
         self._power = STATE_OFF


### PR DESCRIPTION
## Summary

Three fixes: a service-call crash on `fan.turn_on`, a latent variant of the same
bug in `light.turn_off`, and a climate state-restore gap around the power sensor.

## Fixes

### `fan.turn_on` raises TypeError
Home Assistant calls `async_turn_on(percentage, preset_mode, **kwargs)`
**positionally**, but the signature only accepted `percentage`, so any call to
`fan.turn_on` failed with: